### PR TITLE
declaratively managed grafana auth

### DIFF
--- a/configuration/metrics.nix
+++ b/configuration/metrics.nix
@@ -63,9 +63,10 @@
     }
   '';
 
-
-  sops.secrets.grafanaClientSecret = {};
-  sops.secrets.grafanaClientSecret.owner = config.users.users.grafana.name;
+  sops.secrets.grafanaClientSecret = {
+    mode = "0600";
+    owner = "${config.users.users.grafana.name}";
+  };
 
   services.grafana = {
     enable = true;

--- a/configuration/metrics.nix
+++ b/configuration/metrics.nix
@@ -77,21 +77,21 @@
       };
 
       auth = {
-        signout_redirect_url = "https://${routes.authentik.subDomain}.${routes.domain}/application/o/${routes.metrics.applicationSlug}/end-session/";
+        signout_redirect_url = "https://${routes.authentik.subDomain}.${routes.domain}/application/o/grafana/end-session/";
         oauth_auto_login = true;
+        disable_login_form = true;
       };
       "auth.generic_oauth" = {
         name = "authentik";
         enabled = true;
-        client_id = "MuFTPc2aPXUUoL6UKJQJ1cx35Ie5isHVG8cssUqV";
-        client_secret = " $__file{${config.sops.secrets.grafanaClientSecret.path}}";
+        client_id = "AlH37DQbUJxTHq712RsIBJStU1qU2qsmq0lN16X5";
+        client_secret = "$__file{${config.sops.secrets.grafanaClientSecret.path}}";
         scopes = "openid email profile";
         auth_url = "https://${routes.authentik.subDomain}.${routes.domain}/application/o/authorize/";
         token_url = "https://${routes.authentik.subDomain}.${routes.domain}/application/o/token/";
         api_url = "https://${routes.authentik.subDomain}.${routes.domain}/application/o/userinfo/";
-        role_attribute_path = "contains(groups, 'Grafana Admins') && 'Admin' || contains(groups, 'Grafana Editors') && 'Editor' || 'Viewer'";
+        role_attribute_path = "contains(groups, 'grafana Admins') && 'Admin' || 'Viewer'";
       };
-      auth.disable_login_form = true;
     };
     provision.datasources.settings = {
       datasources = [

--- a/routes.nix
+++ b/routes.nix
@@ -25,7 +25,6 @@
     cAdvisor.httpPort = 7080;
     caddy.httpPort = 2019;
     grafana.httpPort = 3000;
-    applicationSlug = "dash"; # todo : correct application slug, can be taken from logout URL on provider overview
   };
 
   outline = {

--- a/routes.nix
+++ b/routes.nix
@@ -25,6 +25,7 @@
     cAdvisor.httpPort = 7080;
     caddy.httpPort = 2019;
     grafana.httpPort = 3000;
+    applicationSlug = "dash"; # todo : correct application slug, can be taken from logout URL on provider overview
   };
 
   outline = {


### PR DESCRIPTION
Declaratively manages grafana auth(atleast on the grafana side of things)
This still needs the actual application slug found in the Authentication provider overview 
![image](https://github.com/user-attachments/assets/ea7213ea-6012-4128-b57d-479ab3176fa7)
between /o/ and /end-session/ to work correctly